### PR TITLE
FixEqualsBug

### DIFF
--- a/src/main/java/Person.java
+++ b/src/main/java/Person.java
@@ -16,7 +16,7 @@ public class Person {
 
         Person person = (Person) o;
 
-        return id == person.id;
+        return id.equals(person.id);
     }
 
     @Override


### PR DESCRIPTION
Integer 对象在-128~127之间取值时，会从缓冲区拿数据比较。超过区间，则会new Integer 对象，所以直接用==是比较两个不同的对象，调用equals，则会拆箱比较value值。