### PR TITLE
使用retainAll方法取交集的时候，会删除不是交集的元素，导致map丢失。修复bug，换用contains判断元素是否存在，然后过滤取…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
 jdk:
-  - oraclejdk8
+  - oraclejdk11
 script: mvn test

--- a/src/main/java/CharCount.java
+++ b/src/main/java/CharCount.java
@@ -1,6 +1,7 @@
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class CharCount {
     /**
@@ -45,7 +46,9 @@ public class CharCount {
         Set<Character> myChars = chars();
         Set<Character> theirChars = anotherCharCount.chars();
 
-        theirChars.retainAll(myChars);
-        return theirChars.size();
+        Set<Character> collect = myChars.stream().filter(theirChars::contains).collect(Collectors.toSet());
+
+        // theirChars.retainAll(myChars);
+        return collect.size();
     }
 }


### PR DESCRIPTION
使用retainAll方法取交集的时候，会删除不是交集的元素，导致map丢失。修复bug，换用contains判断元素是否存在，然后过滤取交集，返回集合。