### PR TITLE
直接相减，会int型溢出，导致计算错误。用Long型数据承接比较计算。

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
 jdk:
-  - oraclejdk8
+  - oraclejdk11
 script: mvn test

--- a/src/main/java/Point.java
+++ b/src/main/java/Point.java
@@ -45,9 +45,11 @@ public class Point {
             public int compare(Point p1, Point p2) {
                 // 按照先x再y，从小到大的顺序排序
                 if (p1.x != p2.x) {
-                    return p1.x - p2.x;
+                    return Long.compare(p1.x, p2.x);
+                    // return p1.x - p2.x;
                 } else {
-                    return p1.y - p2.y;
+                    return Long.compare(p1.y, p2.y);
+                    // return p1.y - p2.y;
                 }
             }
         });


### PR DESCRIPTION
直接相减，会int型溢出，导致计算错误。用Long型数据承接比较计算。