### PR TITLE
修复线程安全List

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
 jdk:
-  - oraclejdk8
+  - oraclejdk11
 script: mvn test

--- a/src/main/java/ConcurrentList.java
+++ b/src/main/java/ConcurrentList.java
@@ -1,5 +1,4 @@
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -7,7 +6,11 @@ import java.util.List;
  * 一个在多线程环境下也能安全的添加元素的List
  */
 public class ConcurrentList {
-    private List<Integer> elements = new ArrayList<>();
+    private  List<Integer> elements = Collections.synchronizedList(new ArrayList<>());
+
+//    public synchronized void add(Integer i) {
+//        elements.add(i);
+//    }
 
     public void add(Integer i) {
         elements.add(i);


### PR DESCRIPTION
1、给集合对象的所有操作方法加同步锁
2、使用Collections.synchronizedList()方法，返回一个线程安全的List